### PR TITLE
linux automated created file is set to ignore in git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,12 @@
 .LSOverride
 
 
+# Linux
+*~
+
+
 /vendor/
+composer.lock
 node_modules/
 npm-debug.log
 yarn-error.log


### PR DESCRIPTION
There should have some files to be ignored like for the automatically created linux file. And I have added the composer.lock file into the gitignore file. It is not necessary when someone pull it.